### PR TITLE
Coverage badge: add support for the code-coverage-api plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Reports a coverage percentage for the following technologies:
 1. Clover: Line coverage percentage
 2. Cobertura: Element coverage percentage
 3. Jacoco: Instruction coverage percentage
+4. Code Coverage API: Line coverage percentage
 
 ### Unit Tests
 Number of JUnit or TestNG tests executed successfully.

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,12 @@
             <version>1.11</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>code-coverage-api</artifactId>
+            <version>1.1.0</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
         <profiles>
                 <!-- Full Mutation testing -->

--- a/src/main/java/org/jenkinsci/plugins/badge/PublicBadgeAction.java
+++ b/src/main/java/org/jenkinsci/plugins/badge/PublicBadgeAction.java
@@ -29,6 +29,8 @@ import static hudson.model.Item.PERMISSIONS;
 import static hudson.model.Item.READ;
 import hudson.model.Job;
 import hudson.model.UnprotectedRootAction;
+import io.jenkins.plugins.coverage.CoverageAction;
+import io.jenkins.plugins.coverage.targets.CoverageElement;
 import hudson.plugins.clover.CloverBuildAction;
 import hudson.plugins.cobertura.CoberturaBuildAction;
 import hudson.plugins.cobertura.targets.CoverageMetric;
@@ -129,6 +131,16 @@ public class PublicBadgeAction implements UnprotectedRootAction {
         Integer codeCoverage = null;
 
         if (project.getLastSuccessfulBuild() != null) {
+            PluginWrapper codeCoverageApiInstalled = getInstance().pluginManager.getPlugin("code-coverage-api");
+            // Checks for Code Coverage API
+            if (codeCoverageApiInstalled != null && codeCoverageApiInstalled.isActive()) {
+                CoverageAction coverageAction = project.getLastSuccessfulBuild().getAction(CoverageAction.class);
+                if (coverageAction != null) {
+                    if (coverageAction.getBuildHealth() != null){
+                        codeCoverage = coverageAction.getResult().getCoverage(CoverageElement.LINE).getPercentage();
+                    }
+                }
+            }
             PluginWrapper jacocoInstalled = getInstance().pluginManager.getPlugin("jacoco");
             // Checks for Jacoco
             if (jacocoInstalled != null && jacocoInstalled.isActive()) {


### PR DESCRIPTION
I added support for the code-coverage-api-plugin ([https://github.com/jenkinsci/code-coverage-api-plugin](https://github.com/jenkinsci/code-coverage-api-plugin))

Currently reports the line coverage percentage.